### PR TITLE
[DO NOT MERGE]Applied Genepi 0001-tntnetSetuid.patch

### DIFF
--- a/framework/runtime/process.cpp
+++ b/framework/runtime/process.cpp
@@ -173,7 +173,7 @@ skip:
 
     log_debug("change user to " << user << '(' << pw->pw_uid << ')');
 
-    int ret = ::setuid(pw->pw_uid);
+    int ret = ::seteuid(pw->pw_uid);
     if (ret != 0)
       throw cxxtools::SystemError("getuid");
   }


### PR DESCRIPTION
Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>
Problem : it is impossible for the program to change privileges afterward and User Management need it.
Solution : use seteuid in place of setuid. 
